### PR TITLE
PhantomJS workaround

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,13 +34,13 @@
     var _toString = ({}).toString;
 
     return function (obj) {
+      if (obj === null) {
+        return 'null';
+      } else if (obj === undefined) {
+        return 'undefined';
+      }
       // [object Blah] -> Blah
       var stype = _toString.call(obj).slice(8, -1);
-
-      if ((obj === null) || (obj === undefined)) {
-        return stype.toLowerCase();
-      }
-
       var ctype = of(obj);
 
       if (ctype && !isBuiltIn(ctype)) {


### PR DESCRIPTION
Hi, @stephenhandley,

This is a workaround for PhantomJS strange behavior that returns `"[object DOMWindow]"` on `Object.prototype.toString.call(undefined)` and `Object.prototype.toString.call(null)`.

see: http://stackoverflow.com/questions/14218670/why-are-null-and-undefined-of-the-type-domwindow

Thanks!
